### PR TITLE
Fixed bento issues

### DIFF
--- a/measure
+++ b/measure
@@ -244,7 +244,7 @@ class Aggregator(Measure):
 
         try:
             f = open(CFG_FILE)
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         except IOError as e:
             return {} # no config, totatly fine
         except yaml.error.YAMLError as e:
@@ -501,12 +501,16 @@ class Aggregator(Measure):
         return output, err_msg
 
 
-    def _run_drivers(self, params=[], stdin={}, term_on_err=False, timeout = 0):
+    def _run_drivers(self, params=None, stdin=None, term_on_err=False, timeout = 0):
         """
         Runs all drivers and returns a dict where keys are the driver names and
         values are the parse stdout of each driver. If any driver retruns an
         error, raise an exception.
         """
+        if params is None:
+            params = []
+        if stdin is None:
+            stdin = {}
 
         # driver commands to run in parallel
         commands = []


### PR DESCRIPTION
Bento Output:

```
bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html  
     > measure_driver.py:247                                                          
     ╷                                                                                
  247│   d = yaml.load(f)                                                             
     ╵
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:371
     ╷
  371│   l = fp.read(4096)
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:381
     ╷
  381│   l = fp.readline()
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:449
     ╷
  449│   l = min(getattr(select, 'PIPE_BUF', 512), len(stdin))
     ╵
     = ambiguous variable name 'l'

flake8 no-mutable-default-args https://github.com/PyCQA/flake8-bugbear/blob/master/README.rst#list-of-warnings
     > measure_driver.py:504
     ╷
  504│   def _run_drivers(self, params=[], stdin={}, term_on_err=False, timeout = 0):
     ╵
     = Do not use mutable data structures for argument defaults.  They are
       created during function definition time. All calls to the function reuse
       this one instance of that data structure, persisting changes between
       them.

flake8 no-mutable-default-args https://github.com/PyCQA/flake8-bugbear/blob/master/README.rst#list-of-warnings
     > measure_driver.py:504
     ╷
  504│   def _run_drivers(self, params=[], stdin={}, term_on_err=False, timeout = 0):
     ╵
     = Do not use mutable data structures for argument defaults.  They are
       created during function definition time. All calls to the function reuse
       this one instance of that data structure, persisting changes between
       them.
```